### PR TITLE
Gravity TOP pulls content up

### DIFF
--- a/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
@@ -18,8 +18,11 @@ internal fun Activity.getStatusBarHeightInPx(): Int {
 
     val statusBarHeight = rectangle.top
     val contentViewTop = window.findViewById<View>(Window.ID_ANDROID_CONTENT).top
-
-    return contentViewTop - statusBarHeight
+    return if (contentViewTop == 0) { //Actionbar is not present
+        statusBarHeight
+    } else {
+        contentViewTop - statusBarHeight
+    }
 }
 
 internal fun Activity.getNavigationBarPosition(): NavigationBarPosition {


### PR DESCRIPTION
If using a theme like Theme.AppCompat.Light.NoActionBar, the getStatusBarHeightInPx function returns a negative value which then pulls the content of the flashbar up.

This could also be what's causing #3 