### PR TITLE
Bugfix navigationbar size

### DIFF
--- a/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
@@ -52,7 +52,6 @@ class Flashbar private constructor(private var builder: Builder) {
 
     private fun construct() {
         flashbarContainerView = FlashbarContainerView(builder.activity)
-        flashbarContainerView.adjustOrientation(builder.activity)
         flashbarContainerView.addParent(this)
 
         flashbarView = FlashbarView(builder.activity)

--- a/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
@@ -15,6 +15,8 @@ import com.andrognito.flashbar.Flashbar.Gravity.TOP
 import com.andrognito.flashbar.anim.FlashAnim
 import com.andrognito.flashbar.anim.FlashAnimBarBuilder
 import com.andrognito.flashbar.anim.FlashAnimIconBuilder
+import com.andrognito.flashbar.util.getContentView
+import com.andrognito.flashbar.util.getRootView
 
 private const val DEFAULT_SHADOW_STRENGTH = 4
 private const val DEFAUT_ICON_SCALE = 1.0f
@@ -28,7 +30,13 @@ class Flashbar private constructor(private var builder: Builder) {
      * Shows a flashbar
      */
     fun show() {
-        flashbarContainerView.show(builder.activity)
+        val anchorViewGroup = if (builder.gravity == TOP) {
+            builder.activity.getRootView()
+        } else {
+            builder.activity.getContentView()
+        } ?: return
+
+        flashbarContainerView.show(anchorViewGroup)
     }
 
     /**

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
@@ -20,6 +20,7 @@ import com.andrognito.flashbar.anim.FlashAnimBarBuilder
 import com.andrognito.flashbar.anim.FlashAnimIconBuilder
 import com.andrognito.flashbar.util.NavigationBarPosition.*
 import com.andrognito.flashbar.util.afterMeasured
+import com.andrognito.flashbar.util.getContentView
 import com.andrognito.flashbar.util.getNavigationBarPosition
 import com.andrognito.flashbar.util.getNavigationBarSizeInPx
 import com.andrognito.flashbar.util.getRootView
@@ -139,16 +140,14 @@ internal class FlashbarContainerView(context: Context)
         layoutParams = flashbarContainerViewLp
     }
 
-
-    internal fun show(activity: Activity) {
+    internal fun show(anchorViewGroup: ViewGroup) {
         if (isBarShowing || isBarShown) return
 
-        val activityRootView = activity.getRootView() ?: return
 
         // Only add the withView to the parent once
-        if (this.parent == null) activityRootView.addView(this)
+        if (this.parent == null) anchorViewGroup.addView(this)
 
-        activityRootView.afterMeasured {
+        anchorViewGroup.afterMeasured {
             val enterAnim = enterAnimBuilder.withView(flashbarView).build()
             enterAnim.start(object : FlashAnim.InternalAnimListener {
                 override fun onStart() {

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
@@ -56,6 +56,10 @@ internal class FlashbarContainerView(context: Context)
     private var showOverlay: Boolean = false
     private var overlayBlockable: Boolean = false
 
+    init {
+        layoutParams = RelativeLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+    }
+
     override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
         when (event.action) {
             ACTION_DOWN -> {

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
@@ -20,10 +20,8 @@ import com.andrognito.flashbar.anim.FlashAnimBarBuilder
 import com.andrognito.flashbar.anim.FlashAnimIconBuilder
 import com.andrognito.flashbar.util.NavigationBarPosition.*
 import com.andrognito.flashbar.util.afterMeasured
-import com.andrognito.flashbar.util.getContentView
 import com.andrognito.flashbar.util.getNavigationBarPosition
 import com.andrognito.flashbar.util.getNavigationBarSizeInPx
-import com.andrognito.flashbar.util.getRootView
 
 /**
  * Container withView matching the height and width of the parent to hold a FlashbarView.

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
@@ -44,27 +44,11 @@ import kotlinx.android.synthetic.main.flash_bar_view.view.*
 internal class FlashbarView(context: Context) : LinearLayout(context) {
 
     private val TOP_COMPENSATION_MARGIN = resources.getDimension(R.dimen.fb_top_compensation_margin).toInt()
-    private val BOTTOM_COMPENSATION_MARGIN = resources.getDimension(R.dimen.fb_bottom_compensation_margin).toInt()
 
     private lateinit var parentFlashbarContainer: FlashbarContainerView
     private lateinit var gravity: Gravity
 
     private var isMarginCompensationApplied: Boolean = false
-
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-
-        if (!isMarginCompensationApplied) {
-            isMarginCompensationApplied = true
-
-            val params = layoutParams as ViewGroup.MarginLayoutParams
-            when (gravity) {
-                TOP -> params.topMargin = -TOP_COMPENSATION_MARGIN
-                BOTTOM -> params.bottomMargin = -BOTTOM_COMPENSATION_MARGIN
-            }
-            requestLayout()
-        }
-    }
 
     internal fun init(
             gravity: Gravity,
@@ -101,7 +85,6 @@ internal class FlashbarView(context: Context) : LinearLayout(context) {
                 flashbarViewLp.addRule(ALIGN_PARENT_TOP)
             }
             BOTTOM -> {
-                flashbarViewContentLp.bottomMargin = BOTTOM_COMPENSATION_MARGIN
                 flashbarViewLp.addRule(ALIGN_PARENT_BOTTOM)
             }
         }

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
@@ -48,8 +48,6 @@ internal class FlashbarView(context: Context) : LinearLayout(context) {
     private lateinit var parentFlashbarContainer: FlashbarContainerView
     private lateinit var gravity: Gravity
 
-    private var isMarginCompensationApplied: Boolean = false
-
     internal fun init(
             gravity: Gravity,
             castShadow: Boolean,

--- a/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
@@ -50,6 +50,13 @@ internal fun Activity?.getRootView(): ViewGroup? {
     if (this == null || window == null || window.decorView == null) {
         return null
     }
+    return window.decorView as? ViewGroup
+}
+
+internal fun Activity?.getContentView(): ViewGroup? {
+    if (this == null || window == null || window.decorView == null) {
+        return null
+    }
     return window.decorView.findViewById(android.R.id.content) as? ViewGroup
 }
 

--- a/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/util/CommonUtils.kt
@@ -50,7 +50,7 @@ internal fun Activity?.getRootView(): ViewGroup? {
     if (this == null || window == null || window.decorView == null) {
         return null
     }
-    return window.decorView as ViewGroup
+    return window.decorView.findViewById(android.R.id.content) as? ViewGroup
 }
 
 internal fun Context.convertDpToPx(dp: Int): Int {


### PR DESCRIPTION
### What’s the problem?
- FlashBar running in Android SDK 29, The problem is that the height of the NavigationBar is calculated incorrectly.
![Screenshot_1621500438](https://user-images.githubusercontent.com/16127348/118949187-8e10f200-b98b-11eb-88df-faabc8b42ced.png)

- FlashBar running in Android SDK 23, Setting the `bottomMargin` of `FlashbarContainerView` does not take effect.
![Screenshot_1621500444](https://user-images.githubusercontent.com/16127348/118949197-8fdab580-b98b-11eb-9e48-eb68bd8c3b83.png)

### Solution
- When `FlashBar` `gravity == bottom`, add `FlashbarContainerView` to the `contentView` of `Activity`, so that we don’t need to set the `bottomMargin` value of `FlashbarContainerView`, avoid calculating the wrong `navigationBar` height value and setting the `bottomMargin` of `FlashbarContainerView` unsuccessfully.
